### PR TITLE
add modal for editing windows content, add 'previous - next' feature on modal

### DIFF
--- a/frontend/src/components/Modal/Modal.css
+++ b/frontend/src/components/Modal/Modal.css
@@ -1,0 +1,43 @@
+.modal {
+  position: fixed;
+  top: 100px;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  width: 70%;
+  margin: 0 auto;
+  height: 60vh;
+  background-color: white;
+  text-align: center;
+  border-radius: 5px;
+  padding: 20px;
+}
+
+.modal .close-modal {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  border: 1px solid #333;
+  padding: 3px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 50%;
+  transition: all 0.15s;
+}
+
+.modal .close-modal:hover {
+  background-color: #333;
+  color: white;
+}
+
+.modal .modal-navigation {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+}
+
+.modal .modal-navigation-item:hover {
+  cursor: pointer;
+  opacity: 0.7;
+}

--- a/frontend/src/components/Modal/Modal.tsx
+++ b/frontend/src/components/Modal/Modal.tsx
@@ -1,0 +1,60 @@
+import "./Modal.css";
+
+import CloseIcon from "@mui/icons-material/Close";
+
+type Props = {
+  day: number;
+  openModal: boolean;
+  setOpenModal: (openModal: boolean) => void;
+  setDay: (day: number) => void;
+  amountOfWindows: number;
+};
+
+const Modal: React.FC<Props> = ({
+  day,
+  setDay,
+  openModal,
+  setOpenModal,
+  amountOfWindows,
+}) => {
+  const handleClick = (direction: string) => {
+    if (direction === "previous") {
+      if (day === 1) {
+        return;
+      }
+      setDay(day - 1);
+    } else {
+      if (day === amountOfWindows) {
+        return;
+      }
+      setDay(day + 1);
+    }
+  };
+
+  return (
+    <div className="modal">
+      <div className="modal-navigation">
+        <div
+          className="modal-navigation-item"
+          onClick={() => handleClick("previous")}
+        >
+          Previous window
+        </div>
+        <div
+          className="modal-navigation-item"
+          onClick={() => handleClick("next")}
+        >
+          Next window
+        </div>
+      </div>
+      <h1>Modal for the {day} window</h1>
+      {openModal && (
+        <div className="close-modal" onClick={() => setOpenModal(false)}>
+          <CloseIcon />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Modal;

--- a/frontend/src/components/Preview.tsx
+++ b/frontend/src/components/Preview.tsx
@@ -2,92 +2,90 @@
 import "./Preview.css";
 
 // components
-import React, { useState } from 'react';
-import FormControl from '@mui/material/FormControl';
-import Input from '@mui/material/Input';
-import InputLabel from '@mui/material/InputLabel';
+import React, { useState } from "react";
+import FormControl from "@mui/material/FormControl";
+import Input from "@mui/material/Input";
+import InputLabel from "@mui/material/InputLabel";
 import Window from "./Window/Window";
 import titleFont from "./Texts";
 import subtitleFont from "./Texts";
 import titleFontSize from "./Texts";
 import subTitleFontSize from "./Texts";
 
-
-
-// this array will be created based on the time user specifies
-const windows = [
-  "1.",
-  "2.",
-  "3.",
-  "4.",
-  "5.",
-  "6.",
-  "7.",
-  "8.",
-  "9.",
-  "10.",
-  "11.",
-  "12.",
-  "13.",
-  "14.",
-  "15.",
-  "16.",
-  "17.",
-  "18.",
-  "19.",
-  "20.",
-  "21.",
-  "22.",
-  "23.",
-  "24.",
-];
-
 type Props = {
-  title : string;
-  subtitle : string;
+  title: string;
+  subtitle: string;
   setTitle: (title: string) => void;
   setSubtitle: (subtitle: string) => void;
+  setOpenModal: (openModal: boolean) => void;
+  setDay: (day: number) => void;
+  windows: number[];
 };
 
-
-const Preview: React.FC<Props> = ({ title, subtitle, setTitle, setSubtitle, titleFont, titleFontSize }) => {
-  
+const Preview: React.FC<Props> = ({
+  title,
+  subtitle,
+  setTitle,
+  setSubtitle,
+  titleFont,
+  titleFontSize,
+  setOpenModal,
+  setDay,
+  windows,
+}) => {
   const onTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(event.target.value);
-  }
+  };
 
   const onSubtitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSubtitle(event.target.value);
-  }
+  };
 
   return (
     <div className="preview">
-    <div>
-    <FormControl >
-          <InputLabel style={{ color: 'lightgrey' }}>Title</InputLabel>
+      <div>
+        <FormControl>
+          <InputLabel style={{ color: "lightgrey" }}>Title</InputLabel>
           <Input
-           value={title}
+            value={title}
             onChange={onTitleChange}
-            style={{ width: '200px', height: '50px',
-              backgroundColor: '#f5f5f5', borderRadius: '4px', fontFamily: titleFont, fontSize: titleFontSize }}
+            style={{
+              width: "200px",
+              height: "50px",
+              backgroundColor: "#f5f5f5",
+              borderRadius: "4px",
+              fontFamily: titleFont,
+              fontSize: titleFontSize,
+            }}
           />
         </FormControl>
         {/* Input field for subtitle with selected font and font size */}
-        <FormControl >
-          <InputLabel style={{ color: 'lightgrey' }}>Subtitle</InputLabel>
+        <FormControl>
+          <InputLabel style={{ color: "lightgrey" }}>Subtitle</InputLabel>
           <Input
-              value={subtitle}
+            value={subtitle}
             onChange={onSubtitleChange}
-            style={{ width: '200px', height: '150px', backgroundColor: '#f5f5f5', borderRadius: '4px', fontFamily: subtitleFont, fontSize: subTitleFontSize }}
+            style={{
+              width: "200px",
+              height: "150px",
+              backgroundColor: "#f5f5f5",
+              borderRadius: "4px",
+              fontFamily: subtitleFont,
+              fontSize: subTitleFontSize,
+            }}
           />
         </FormControl>
-      <div>{title}</div>
-      <div>{subtitle}</div>
-   
+        <div>{title}</div>
+        <div>{subtitle}</div>
       </div>
       <div className="windows">
         {windows.map((window) => (
-          <Window key={window} day={window} />
+          <Window
+            key={window}
+            day={window}
+            setOpenModal={setOpenModal}
+            setDay={setDay}
+          />
         ))}
       </div>
     </div>

--- a/frontend/src/components/Window/Window.tsx
+++ b/frontend/src/components/Window/Window.tsx
@@ -4,13 +4,15 @@ import "./Window.css";
 import AddIcon from "@mui/icons-material/Add";
 
 type Props = {
-  day: string;
+  day: number;
+  setOpenModal: (openModal: boolean) => void;
+  setDay: (day: number) => void;
 };
 
-const Window: React.FC<Props> = ({ day }) => {
-  // this function will be called when user clicks on the windows add icon, will open up a modal
-  const handleClick = (day: string) => {
-    console.log(`Clicked on ${day} day`);
+const Window: React.FC<Props> = ({ day, setOpenModal, setDay }) => {
+  const handleClick = (day: number) => {
+    setOpenModal(true);
+    setDay(day);
   };
 
   return (

--- a/frontend/src/routes/Panel.css
+++ b/frontend/src/routes/Panel.css
@@ -1,4 +1,5 @@
 .panel {
+  position: relative;
   display: flex;
   margin-top: 65px;
   min-height: 100vh;

--- a/frontend/src/routes/Panel.tsx
+++ b/frontend/src/routes/Panel.tsx
@@ -5,16 +5,44 @@ import { useState } from "react";
 // components
 import Sidebar from "../components/Sidebar";
 import Preview from "../components/Preview";
+import Modal from "../components/Modal/Modal";
 
 const Panel: React.FC = () => {
-
   const [title, setTitle] = useState("");
   const [subtitle, setSubtitle] = useState("");
+  const [openModal, setOpenModal] = useState(false);
+  const [day, setDay] = useState(1);
+  const [windows, setWindows] = useState([
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+    22, 23, 24,
+  ]);
 
   return (
     <div className="panel">
-      <Sidebar title={title} subtitle={subtitle} setTitle={setTitle} setSubtitle={setSubtitle}/>
-      <Preview title={title} subtitle={subtitle} setTitle={setTitle} setSubtitle={setSubtitle}/>
+      <Sidebar
+        title={title}
+        subtitle={subtitle}
+        setTitle={setTitle}
+        setSubtitle={setSubtitle}
+      />
+      <Preview
+        title={title}
+        subtitle={subtitle}
+        setTitle={setTitle}
+        setSubtitle={setSubtitle}
+        setOpenModal={setOpenModal}
+        setDay={setDay}
+        windows={windows}
+      />
+      {openModal && (
+        <Modal
+          day={day}
+          openModal={openModal}
+          setOpenModal={setOpenModal}
+          setDay={setDay}
+          amountOfWindows={windows.length}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
- created a modal to open up when clicking the plus icon on the preview windows
- option to close the modal or travel between the windows by clicking the next or previous

<img width="764" alt="modal" src="https://github.com/aj-kivimaki/digital-calendar/assets/121675713/e54ef85f-ff32-4eb2-8b28-81afb189b897">

- changed the windows variable to be a state (array of numbers) - this will be created by the timeline user specifies

Here's the list of features to add on this modal:
<img width="568" alt="features" src="https://github.com/aj-kivimaki/digital-calendar/assets/121675713/6fcf6c05-6468-42af-9b5e-eeeac0f925ba">

