### PR TITLE
change the modals to occupy space only on top of the preview

### DIFF
--- a/frontend/src/components/Modal/Modal.css
+++ b/frontend/src/components/Modal/Modal.css
@@ -1,16 +1,12 @@
 .modal {
-  position: fixed;
-  top: 100px;
-  left: 0;
-  right: 0;
-  z-index: 1000;
-  width: 70%;
+  width: 95%;
   margin: 0 auto;
-  height: 60vh;
+  min-height: 60vh;
   background-color: white;
   text-align: center;
   border-radius: 5px;
   padding: 20px;
+  position: relative;
 }
 
 .modal .close-modal {

--- a/frontend/src/components/Preview.css
+++ b/frontend/src/components/Preview.css
@@ -5,6 +5,7 @@
   width: 100%;
   background-color: lightgrey;
   position: relative;
+  min-width: 500px;
 }
 
 .preview .container {
@@ -36,4 +37,13 @@
   position: absolute;
   top: 5px;
   right: 5px;
+}
+
+.preview .modal-create,
+.preview .modal-preview {
+  position: absolute;
+  top: 20px;
+  right: 0;
+  z-index: 1000;
+  width: 100%;
 }

--- a/frontend/src/components/Preview.tsx
+++ b/frontend/src/components/Preview.tsx
@@ -4,12 +4,15 @@ import "./Preview.css";
 // components
 import Window from "./Window/Window";
 import MusicPlayer from "./SidebarSounds/MusicPlayer";
+import Modal from "../components/Modal/Modal";
+import PreviewModal from "../components/PreviewModal/PreviewModal";
 
 import { Typography } from "@mui/material";
 
 // sounds
 // this will come from the server later
 import selectedBgMusic from "../assets/music/xmas-music.mp3";
+import { useState } from "react";
 
 type Props = {
   title: string;
@@ -24,14 +27,13 @@ type Props = {
   setSubTitleFontSize: (subTitleFontSize: number) => void;
   subtitleFont: string;
   subTitleFontSize: number;
-  setOpenModal: (openModal: boolean) => void;
   setDay: (day: number) => void;
   windows: number[];
   titleColor: string;
   subtitleColor: string;
   setTitleColor: (color: string) => void;
   setSubtitleColor: (color: string) => void;
-  setOpenPreviewModal: (openPreviewModal: boolean) => void;
+  day: number;
 };
 
 const Preview: React.FC<Props> = ({
@@ -43,15 +45,17 @@ const Preview: React.FC<Props> = ({
   titleFontSize,
   subtitleFont,
   subTitleFontSize,
-  setOpenModal,
   setDay,
+  day,
   windows,
   titleColor,
   subtitleColor,
   /* setTitleColor,
   setSubtitleColor, */
-  setOpenPreviewModal,
 }) => {
+  const [openPreviewModal, setOpenPreviewModal] = useState(false);
+  const [openModal, setOpenModal] = useState(false);
+
   const onTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(event.target.value);
   };
@@ -100,6 +104,26 @@ const Preview: React.FC<Props> = ({
           />
         ))}
       </div>
+      {openModal && (
+        <div className="modal-create">
+          <Modal
+            day={day}
+            openModal={openModal}
+            setOpenModal={setOpenModal}
+            setDay={setDay}
+            amountOfWindows={windows.length}
+          />
+        </div>
+      )}
+      {openPreviewModal && (
+        <div className="modal-preview">
+          <PreviewModal
+            day={day}
+            openPreviewModal={openPreviewModal}
+            setOpenPreviewModal={setOpenPreviewModal}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/routes/Panel.tsx
+++ b/frontend/src/routes/Panel.tsx
@@ -5,8 +5,6 @@ import { useState } from "react";
 // components
 import Sidebar from "../components/Sidebar";
 import Preview from "../components/Preview";
-import Modal from "../components/Modal/Modal";
-import PreviewModal from "../components/PreviewModal/PreviewModal";
 
 const Panel: React.FC = () => {
   const fontOptions = [
@@ -33,13 +31,11 @@ const Panel: React.FC = () => {
   const [subTitleFontSize, setSubTitleFontSize] = useState<number>(
     fontSizeOptions[0]
   );
-  const [openModal, setOpenModal] = useState(false);
   const [day, setDay] = useState(1);
   const [windows /* , setWindows */] = useState([
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
     22, 23, 24,
   ]);
-  const [openPreviewModal, setOpenPreviewModal] = useState(false);
   const [titleColor, setTitleColor] = useState("#000000");
   const [subtitleColor, setSubtitleColor] = useState("#000000");
 
@@ -77,32 +73,14 @@ const Panel: React.FC = () => {
         setSubtitleFont={setSubtitleFont}
         setTitleFontSize={setTitleFontSize}
         setSubTitleFontSize={setSubTitleFontSize}
-        setOpenModal={setOpenModal}
         setDay={setDay}
         windows={windows}
         titleColor={titleColor}
         subtitleColor={subtitleColor}
         setTitleColor={setTitleColor}
         setSubtitleColor={setSubtitleColor}
-        setOpenPreviewModal={setOpenPreviewModal}
+        day={day}
       />
-
-      {openModal && (
-        <Modal
-          day={day}
-          openModal={openModal}
-          setOpenModal={setOpenModal}
-          setDay={setDay}
-          amountOfWindows={windows.length}
-        />
-      )}
-      {openPreviewModal && (
-        <PreviewModal
-          day={day}
-          openPreviewModal={openPreviewModal}
-          setOpenPreviewModal={setOpenPreviewModal}
-        />
-      )}
     </div>
   );
 };


### PR DESCRIPTION
moved modals to preview component

- both modals occupy space only on top of preview, so that the sidebar will stay visible all times
