### PR TITLE
add navigate to /calendars/:savedCalendarId after saving calendar

### DIFF
--- a/frontend/src/components/LandingPage/Header.tsx
+++ b/frontend/src/components/LandingPage/Header.tsx
@@ -30,12 +30,16 @@ const Header: React.FC = () => {
           <Link to="/calendars" className={styles.navLink}>
             <Button color="inherit">Browse Calendars</Button>
           </Link>
-          <Link to="/panel" className={styles.navLink}>
-            <Button color="inherit">Create Calendar</Button>
-          </Link>
-          <Link to="/favourites" className={styles.navLink}>
-            <Button color="inherit">Favourites</Button>
-          </Link>
+          {token && (
+            <>
+              <Link to="/panel" className={styles.navLink}>
+                <Button color="inherit">Create Calendar</Button>
+              </Link>
+              <Link to="/favourites" className={styles.navLink}>
+                <Button color="inherit">Favourites</Button>
+              </Link>
+            </>
+          )}
         </div>
         <div className={styles.rightAlign}>
           {token ? (

--- a/frontend/src/components/Preview.tsx
+++ b/frontend/src/components/Preview.tsx
@@ -14,6 +14,7 @@ import PreviewModal from "../components/PreviewModal/PreviewModal";
 import { Button, Typography } from "@mui/material";
 
 import { useAppSelector } from "../hooks/useAppDispatch";
+import { useNavigate } from "react-router";
 
 type Props = {
   title: string;
@@ -100,6 +101,8 @@ const Preview: React.FC<Props> = ({
   const token = useAppSelector((state) => state.token.token);
   const uid = useAppSelector((state) => state.uid.uid);
 
+  const navigate = useNavigate();
+
   const onTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(event.target.value);
   };
@@ -142,7 +145,7 @@ const Preview: React.FC<Props> = ({
         data: json,
       })
       .then((response) => {
-        console.log(response.data);
+        navigate(`/calendars/${response.data.calendarId}`);
       })
       .catch((error) => {
         console.error("Error saving calendar:", error);


### PR DESCRIPTION
conditionally show on header, only if logged in
- favourites link
- create calendar link

when user clicks 'save calendar' button
- navigates to /calendars/:calendarId page (calendarId = the calendar user just saved)